### PR TITLE
Fix memory overflow

### DIFF
--- a/classes/tool_image_optimize_helper.php
+++ b/classes/tool_image_optimize_helper.php
@@ -417,7 +417,8 @@ class tool_image_optimize_helper extends \tool_image_optimize {
     protected function update_fileinfo($fileold, $filenew) : void {
         global $DB;
 
-        $relatedreferences = $DB->get_records('files', ['contenthash' => $fileold->contenthash]);
+        $relatedreferences = $DB->get_records_select('files', 'contenthash = :contenthash',
+                ['contenthash' => $fileold->contenthash], '', 'id');
 
         foreach ($relatedreferences as $fileobject) {
             // Update files table.


### PR DESCRIPTION
Instead of selecting all columns, only id is necessary to be selected. If there are millions of entries to update it fixes a memory overflow that results in a fatal error.